### PR TITLE
Releasing as v1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "jquery": "~2.1.4",
     "bsp-utils": "perfectsense/brightspot-js-utils#~3.0.0",
-    "bsp-feature-detect": "rustytanton/brightspot-js-feature-detect#brightspot-base",
+    "bsp-feature-detect": "rustytanton/brightspot-js-feature-detect#^1.0.0",
     "datetimepicker": "~2.4.5"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "jquery": "~2.1.4",
     "bsp-utils": "perfectsense/brightspot-js-utils#~3.0.0",
-    "bsp-feature-detect": "rustytanton/brightspot-js-feature-detect#^1.0.0",
+    "bsp-feature-detect": "perfectsense/brightspot-js-feature-detect#^1.0.0",
     "datetimepicker": "~2.4.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightspot-js-forms",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -13,13 +13,13 @@
     "es6-module-loader": "^0.17.3",
     "express": "^4.13.1",
     "jasmine-core": "^2.3.4",
-    "karma": "^0.12.36",
-    "karma-jasmine": "^0.3.5",
-    "karma-phantomjs-launcher": "^0.2.0",
-    "karma-systemjs": "^0.5.0",
+    "karma": "0.12.36",
+    "karma-jasmine": "0.3.5",
+    "karma-phantomjs-launcher": "0.2.0",
+    "karma-systemjs": "0.5.0",
     "lodash": "^3.10.0",
     "phantomjs": "^1.9.17",
     "phantomjs-polyfill": "0.0.1",
-    "systemjs": "^0.18.3"
+    "systemjs": "0.18.3"
   }
 }


### PR DESCRIPTION
I'd like to release this plugin as v1.0.0 so that we can start using the full semver ranges in our package managers. This also removes unnecessary caret range specifiers from its "major zero" dependencies.
